### PR TITLE
Update MultiBotEngine.lua

### DIFF
--- a/MultiBotEngine.lua
+++ b/MultiBotEngine.lua
@@ -310,8 +310,6 @@ end
 -- 	MultiBotGlobalSave[tName] =  tLocalRace .. "," .. tGender .. "," .. tSpecial .. "," .. tTabs[1] .. "/" .. tTabs[2] .. "/" .. tTabs[3] .. "," .. tLocalClass .. "," .. tLevel .. "," .. tScore
 -- end
 
--- MultiBotEngine.lua
-
 MultiBot.RaidPool = function(pUnit, oWho)
 	-- do nothing if not a bot or the player themselves
 	if(pUnit ~= "player" and MultiBot.getBot(pUnit) == nil) then return end


### PR DESCRIPTION
Hello Macx-Lio,

Alright, I’ve got my brain back in place. :D
The modification you made for the classes works perfectly — the problem was elsewhere:

When adding a bot of class (“chasseresse” — feminine hunter in French) or (“guerrière” — feminine warrior in French), Lua would throw the following error:

1x MultiBot-2.0.0\MultiBotEngine.lua:304: attempt to compare two nil values
MultiBot-2.0.0\MultiBotHandler.lua:707: in function <MultiBot\MultiBotHandler.lua:71>

Locals:
tButton = <unnamed> {
 parent = <unnamed> {}
 class = "Hunter"
 doLeft = <function> @ MultiBot\MultiBotHandler.lua:404:
 setPoint = <function> @ MultiBot\MultiBotEngine.lua:733:
 size = 32
 tip = "Hunter - Erarion
Ce bouton ajoute ou supprime Erarion de votre groupe.
MultiBot demandera à Playerbot les stratégies de combat et hors-combat.
Les stratégies peuvent être configurées avec les barres de boutons à gauche et à droite.
Les barres de boutons apparaîtront après l'ajout du Bot.

Clic gauche pour ajouter Erarion
(Ordre d'exécution : Système)

Clic droit pour supprimer Erarion
(Ordre d'exécution : Système)"
 setTexture = <function> @ MultiBot\MultiBotEngine.lua:748:
 setAmount = <function> @ MultiBot\MultiBotEngine.lua:760:
 y = 0
 addMacro = <function> @ MultiBot\MultiBotEngine.lua:725:
 name = "Erarion"
 getClass = <function> @ MultiBot\MultiBotEngine.lua:795:
 get = <function> @ MultiBot\MultiBotEngine.lua:803:
 setHighlight = <function> @ MultiBot\MultiBotEngine.lua:755:
 combat = "aoe, avoid aoe, bdps, boost, cast time, chat, default, dps, dps assist, dps debuff, duel, formation, potions, racials"
 border = <unnamed> {}
 doShow = <function> @ MultiBot\MultiBotEngine.lua:816:
 roster = "players"
 texture = "MultiBot\Icons\class_hunter.blp"
 normal = "bdps, chat, default, dps assist, duel, emote, follow, food, gather, loot, mount, nc, pet, pvp, quest"
 doRight = <function> @ MultiBot\MultiBotHandler.lua:397:
 setDisable = <function> @ MultiBot\MultiBotEngine.lua:769:
 setEnable = <function> @ MultiBot\MultiBotEngine.lua:777:
 setButton = <function> @ MultiBot\MultiBotEngine.lua:740:
 getName = <function> @ MultiBot\MultiBotEngine.lua:799:
 state = true
 getButton = <function> @ MultiBot\MultiBotEngine.lua:787:
 getFrame = <function> @ MultiBot\MultiBotEngine.lua:791:
 waitFor = ""
 0 = <userdata>
 doHide = <function> @ MultiBot\MultiBotEngine.lua:809:
 icon = <unnamed> {}
 x = 0
}

  ---
  
Why the error occurs:

The code assumes that the block "(xx/yy/zz)" containing the talent distribution is always the 4ᵗʰ word (tSpace[4]) in the /who result.
In French, this assumption is unreliable:

The keyword "Chasseresse" (female version of "Hunter") shifts all indices by one position;

When the block "(xx/yy/zz)" is not present at index 4, the parsing line

tTabs = MultiBot.doSplit(strsub(tSpace[4], 2, strlen(tSpace[4])-1), "/")
returns only one value (or none).
As a result, tTabs[2] or tTabs[3] is nil, and the next line tries to do:


tTabs[3] > tTabs[2]        -- comparison with nil  ⇒  crash
Which causes: attempt to compare two nil values.

Fix:

Dynamically search for the block "(xx/yy/zz)" instead of assuming its position.

Neutralize any missing value by converting it to 0, to avoid comparisons with nil.

Practical effect:

If the /who string varies (due to language, gender, absence of "Level", etc.), the talent block is still detected.

In case of doubt or unexpected format, the three values default safely to 0 / 0 / 0, which prevents any crash and allows the addon to keep functioning.

The fix will also solve the issue for all languages.

